### PR TITLE
add support for HTML imports

### DIFF
--- a/lib/url-join.html
+++ b/lib/url-join.html
@@ -1,0 +1,1 @@
+<script src="./url-join.js"></script>


### PR DESCRIPTION
When using with web components, different components can add their own .js file so it gets loaded multiple times. HTML imports solves this problem and it's a good practice to only load 3rd party scripts like this:

``` html
<link rel="import" href="url-join.html">
```
