### PR TITLE
fixed query string handling, closes #9, closes #4

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -13,7 +13,10 @@
     str = str.replace(/([^:\s])\/+/g, '$1/');
 
     // remove trailing slash before parameters or hash
-    str = str.replace(/\/(\?|#)/g, '$1');
+    str = str.replace(/\/(\?|&|#)/g, '$1');
+
+    // replace ? in parameters with &
+    str = str.replace(/(\?.+)\?/g, '$1&');
 
     return str;
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -30,4 +30,12 @@ describe('url join', function () {
     urljoin('//www.google.com', 'foo/bar', '?test=123')
       .should.eql('//www.google.com/foo/bar?test=123')
   });
+
+  it('should merge multiple query params properly', function () {
+    urljoin('http:', 'www.google.com///', 'foo/bar', '?test=123', '?key=456')
+      .should.eql('http://www.google.com/foo/bar?test=123&key=456');
+
+    urljoin('http:', 'www.google.com///', 'foo/bar', '?test=123', '?boom=value', '&key=456')
+      .should.eql('http://www.google.com/foo/bar?test=123&boom=value&key=456');
+  });
 });


### PR DESCRIPTION
this includes the new test from @jonathansamines in #9 and a modified version of his query string handling to replace `?` inside the query string with `&`