### PR TITLE
Add support for hash urls

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -13,7 +13,7 @@
     str = str.replace(/([^:\s])\/+/g, '$1/');
 
     // remove trailing slash before parameters or hash
-    str = str.replace(/\/(\?|&|#[^!])/g, '$1');
+    str = str.replace(/\/(\?|&|#(\w+)$)/g, '$1');
 
     // replace ? in parameters with &
     str = str.replace(/(\?.+)\?/g, '$1&');

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,6 +16,11 @@ describe('url join', function () {
       .should.eql('http://www.google.com/#!/foo/bar?test=123');
   });
 
+  it('should work hash urls', function() {
+    urljoin(['http://www.google.com', '#', 'foo/bar', '?test=123'])
+      .should.eql('http://www.google.com/#/foo/bar?test=123');
+  });
+
   it('should be able to join protocol', function () {
     urljoin('http:', 'www.google.com/', 'foo/bar', '?test=123')
       .should.eql('http://www.google.com/foo/bar?test=123');


### PR DESCRIPTION
This PR adds support for `http://yolo.com/#/my/cool/url` (not just `http://yolo.com/#!/my/cool/url`)
