### PR TITLE
updated dependencies, added trailingSlash option

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -12,8 +12,10 @@
     // remove consecutive slashes
     str = str.replace(/([^:\s])\/+/g, '$1/');
 
-    // remove trailing slash before parameters or hash
-    str = str.replace(/\/(\?|&|#[^!])/g, '$1');
+    if (!options.trailingSlash) {
+      // remove trailing slash before parameters or hash
+      str = str.replace(/\/(\?|&|#[^!]|#$)/g, '$1');
+    }
 
     // replace ? in parameters with &
     str = str.replace(/(\?.+)\?/g, '$1&');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",
   "devDependencies": {
-    "should": "~1.2.1",
-    "mocha": "~1.8.1"
+    "mocha": "^3.0.2",
+    "should": "^11.1.0"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,4 +48,24 @@ describe('url join', function () {
     urljoin('http:', 'www.google.com///', 'foo/bar', '?test=123', '?boom=value', '&key=456')
       .should.eql('http://www.google.com/foo/bar?test=123&boom=value&key=456');
   });
+
+  it('should handle slashes around hash correctly', function() {
+    urljoin(['https://google.com', '#', 'foobar'])
+      .should.eql('https://google.com#/foobar');
+
+    urljoin(['https://google.com', '#', 'foobar'], {trailingSlash: true})
+      .should.eql('https://google.com/#/foobar');
+
+    urljoin(['https://google.com', '#'])
+      .should.eql('https://google.com#');
+
+    urljoin(['https://google.com', '#'], {trailingSlash: true})
+      .should.eql('https://google.com/#');
+
+    urljoin(['https://google.com', '#/something'])
+      .should.eql('https://google.com#/something');
+
+    urljoin(['https://google.com', '#/something'], {trailingSlash: true})
+      .should.eql('https://google.com/#/something');
+  })
 });


### PR DESCRIPTION
**Updated Dependencies**: the dependencies for testing (mocha, should) were out of date. I updated them which also makes test output much nicer.

**added trailingSlash option**: Using url-join with the arguments of an array of url parts and an object for settings now allows to set the `trailingSlash` option, which will keep slashes in front of `#` and `?` instead of removing them.

Sample:

``` javascript
urljoin(['https://google.com', '#', 'foobar'])                        // outputs https://google.com#/foobar
urljoin(['https://google.com', '#', 'foobar'], {trailingSlash: true}) // outputs https://google.com/#/foobar
```
