### PR TITLE
Add file protocol support

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -4,16 +4,27 @@
   else context[name] = definition();
 })('urljoin', this, function () {
 
+  if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      position = position || 0;
+      return this.substr(position, searchString.length) === searchString;
+    };
+  }
+
   function normalize (str, options) {
 
-    // make sure protocol is followed by two slashes
-    str = str.replace(/:\//g, '://');
+    if (str.startsWith('file://')) {
 
-    // remove consecutive slashes
-    str = str.replace(/([^:\s])\/+/g, '$1/');
+      // make sure file protocol has max three slashes
+      str = str.replace(/(\/{0,3})\/*/g, '$1');
+    } else {
 
-    // set file:// for file protocol
-    str = str.replace(/(file:)\/+/g, '$1///');
+      // make sure protocol is followed by two slashes
+      str = str.replace(/:\//g, '://');
+
+      // remove consecutive slashes
+      str = str.replace(/([^:\s])\/+/g, '$1/');
+    }
 
     // remove trailing slash before parameters or hash
     str = str.replace(/\/(\?|&|#[^!])/g, '$1');

--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -12,6 +12,9 @@
     // remove consecutive slashes
     str = str.replace(/([^:\s])\/+/g, '$1/');
 
+    // set file:// for file protocol
+    str = str.replace(/(file:)\/+/g, '$1///');
+
     // remove trailing slash before parameters or hash
     str = str.replace(/\/(\?|&|#[^!])/g, '$1');
 

--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -4,16 +4,13 @@
   else context[name] = definition();
 })('urljoin', this, function () {
 
-  if (!String.prototype.startsWith) {
-    String.prototype.startsWith = function(searchString, position){
-      position = position || 0;
-      return this.substr(position, searchString.length) === searchString;
-    };
+  function startsWith(str, searchString) {
+    return str.substr(0, searchString.length) === searchString;
   }
 
   function normalize (str, options) {
 
-    if (str.startsWith('file://')) {
+    if (startsWith(str, 'file://')) {
 
       // make sure file protocol has max three slashes
       str = str.replace(/(\/{0,3})\/*/g, '$1');

--- a/test/tests.js
+++ b/test/tests.js
@@ -42,16 +42,24 @@ describe('url join', function () {
   });
 
   it('should support file protocol urls', function () {
-    urljoin('file:', 'android_asset', 'foo/bar')
-      .should.eql('file:///android_asset/foo/bar')
+    urljoin('file:/', 'android_asset', 'foo/bar')
+      .should.eql('file://android_asset/foo/bar')
 
+    urljoin('file:', '/android_asset', 'foo/bar')
+      .should.eql('file://android_asset/foo/bar')
+  });
+
+  it('should support absolute file protocol urls', function () {
     urljoin('file:', '///android_asset', 'foo/bar')
       .should.eql('file:///android_asset/foo/bar')
 
-    urljoin('file:', '/android_asset', 'foo/bar')
+    urljoin('file:///', 'android_asset', 'foo/bar')
       .should.eql('file:///android_asset/foo/bar')
 
-    urljoin('file:///', 'android_asset', 'foo/bar')
+    urljoin('file:///', '//android_asset', 'foo/bar')
+      .should.eql('file:///android_asset/foo/bar')
+
+    urljoin('file:///android_asset', 'foo/bar')
       .should.eql('file:///android_asset/foo/bar')
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -41,6 +41,20 @@ describe('url join', function () {
       .should.eql('//www.google.com/foo/bar?test=123')
   });
 
+  it('should support file protocol urls', function () {
+    urljoin('file:', 'android_asset', 'foo/bar')
+      .should.eql('file:///android_asset/foo/bar')
+
+    urljoin('file:', '///android_asset', 'foo/bar')
+      .should.eql('file:///android_asset/foo/bar')
+
+    urljoin('file:', '/android_asset', 'foo/bar')
+      .should.eql('file:///android_asset/foo/bar')
+
+    urljoin('file:///', 'android_asset', 'foo/bar')
+      .should.eql('file:///android_asset/foo/bar')
+  });
+
   it('should merge multiple query params properly', function () {
     urljoin('http:', 'www.google.com///', 'foo/bar', '?test=123', '?key=456')
       .should.eql('http://www.google.com/foo/bar?test=123&key=456');


### PR DESCRIPTION
Support for file protocol.

My use case is on cordova, with URLs like: `file:///android_asset/...`

Published this version at: https://www.npmjs.com/package/@xtuc/url-join