### PR TITLE
Avoid removing consecutive slashes on encoded URLs

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -20,7 +20,7 @@
       str = str.replace(/:\//g, '://');
 
       // remove consecutive slashes
-      str = str.replace(/([^:\s])\/+/g, '$1/');
+      str = str.replace(/([^:\s%3A])\/+/g, '$1/');
     }
 
     // remove trailing slash before parameters or hash

--- a/test/tests.js
+++ b/test/tests.js
@@ -31,6 +31,11 @@ describe('url join', function () {
       .should.eql('http://www.google.com/foo/bar?test=123');
   });
 
+  it('should not remove extra slashes in an encoded URL', function () {
+    urljoin('http:', 'www.google.com///', 'foo/bar', '?url=http%3A//Ftest.com')
+      .should.eql('http://www.google.com/foo/bar?url=http%3A//Ftest.com');
+  });
+
   it('should support anchors in urls', function () {
     urljoin('http:', 'www.google.com///', 'foo/bar', '?test=123', '#faaaaa')
       .should.eql('http://www.google.com/foo/bar?test=123#faaaaa');


### PR DESCRIPTION
For some reason https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString doesn't encode slashes (`encodeURIComponent` does).

I added a test which is my use case for this.