### PR TITLE
Remove duplicate slashes for absolute paths

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -23,6 +23,11 @@
       str = str.replace(/([^:\s\%\3\A])\/+/g, '$1/');
     }
 
+    if (!options.isRelativeProtocol) {
+      // remove double forward slashes
+      str = str.replace(/^\/\/+/g, '/');
+    }
+
     // remove trailing slash before parameters or hash
     str = str.replace(/\/(\?|&|#[^!])/g, '$1');
 
@@ -41,6 +46,8 @@
       input = arguments[0];
       options = arguments[1] || {};
     }
+
+    options.isRelativeProtocol = /^\/{2}.*/.test(input[0])
 
     var joined = [].slice.call(input, 0).join('/');
     return normalize(joined, options);

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,6 +48,17 @@ describe('url join', function () {
   it('should support protocol-relative urls', function () {
     urljoin('//www.google.com', 'foo/bar', '?test=123')
       .should.eql('//www.google.com/foo/bar?test=123')
+
+    urljoin('//', 'www.google.com', 'foo/bar', '?test=123')
+      .should.eql('//www.google.com/foo/bar?test=123')
+  });
+
+  it('should remove duplicate slashes for absolute paths', function () {
+    urljoin('/', '/foo/bar', '?test=123')
+      .should.eql('/foo/bar?test=123')
+
+    urljoin('', '/', '/foo/bar', '?test=123')
+      .should.eql('/foo/bar?test=123')
   });
 
   it('should support file protocol urls', function () {


### PR DESCRIPTION
In keeping with @ArmorDarks comment about 

> I think that relative protocol should be supported only when it's passed explicitly.


https://github.com/jfromaniello/url-join/issues/16#issuecomment-282554396

This

```
urljoin('/', '/some')
```
should return `/some`

And this

```
urljoin('//', '/some')
```
should return `//some`, since we passed in relative protocol explicitly.