### PR TITLE
Preserve leading slashes, fixes #45

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -13,6 +13,11 @@
       strArray[0] = first + strArray[0];
     }
 
+    // A leading slash without a protocol indicates that the output should also
+    // have a leading slash.
+    var shouldHaveLeadingSlash = strArray.join('')[0] === '/' &&
+      !strArray.join('').match(/[^/:]+:\/*$/);
+
     // There must be two or three slashes in the file protocol, two slashes in anything else.
     if (strArray[0].match(/^file:\/\/\//)) {
       strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///');
@@ -54,6 +59,9 @@
     // replace ? in parameters with &
     var parts = str.split('?');
     str = parts.shift() + (parts.length > 0 ? '?': '') + parts.join('&');
+
+    // Ensure that the output has a leading slash
+    if (shouldHaveLeadingSlash && str[0] !== '/') str = '/' + str;
 
     return str;
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -99,6 +99,11 @@ describe('url join', function () {
       .should.eql('/test');
   });
 
+  it('should preserve a leading slash in a path', function(){
+    urljoin('', '/test').should.eql('/test');
+    urljoin('', '', '/test').should.eql('/test');
+  });
+
   it('should fail with segments that are not string', function() {
     assert.throws(() => urljoin('http://blabla.com/', 1),
                   /Url must be a string. Received 1/);


### PR DESCRIPTION
This fixes an issue where a leading slash character would not appear when expected.

A little background:

I was using `urlJoin` to create url paths in an app that has an optional leading path. This optional leading path is a language code that specifies an alternative site translation.

```javascript
// no alternative specified
urlJoin('', '/some-path')

// there is one specified
urlJoin('/es', '/some-path')
```

It seems like this is the sort of thing that `urlJoin` is meant for, but it didn't handle this particular case. I found another issue #45 that seemed related so I figured I'd open a pull request.