### PR TITLE
Reduce package size by adding "files" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha --require should"
   },
+  "files": ["lib/"],
   "repository": {
     "type": "git",
     "url": "git://github.com/jfromaniello/url-join.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha --require should"
   },
-  "files": ["lib/"],
+  "files": ["lib"],
   "repository": {
     "type": "git",
     "url": "git://github.com/jfromaniello/url-join.git"


### PR DESCRIPTION
I greatly appreciate this great and simple library you developed to join URLs.

Because your library is so famous and so many installed, it would be nice if the package size gets smaller.

This PR just suggests to reduce the package size by adding ["files" field](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) to package.json

This change will make the package size smaller.

I checked how effective it is by comparing the sizes as following.

Without "files" field: 18.3 kB

```
$ npm publish --dry-run 2>&1 | grep "unpacked size"
npm notice unpacked size: 18.3 kB
```

With "files" field: 4.8 kB

```
$ npm publish --dry-run 2>&1 | grep "unpacked size"
npm notice unpacked size: 4.8 kB
```

Thank you.