### PR TITLE
Rename master branch to 'main'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will require the `master` branch to be renamed to `main` ([more information](https://github.com/github/renaming)).