### PR TITLE
Add Dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,13 @@ updates:
     rebase-strategy: disabled
     schedule:
       interval: weekly
+    labels:
+      - dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies


### PR DESCRIPTION
Keeps our Github Actions up-to-date automatically.