### PR TITLE
Add Node.js 18 to testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds the recently released Node.js 18 to the testing matrix as this will be a future LTS version.