### PR TITLE
Use modern JavaScript for 'urlJoin' function

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -57,14 +57,7 @@ function normalize (strArray) {
   return str;
 }
 
-export default function urlJoin() {
-  var input;
-
-  if (typeof arguments[0] === 'object') {
-    input = arguments[0];
-  } else {
-    input = [].slice.call(arguments);
-  }
-
-  return normalize(input);
+export default function urlJoin(...args) {
+  const parts = Array.from(Array.isArray(args[0]) ? args[0] : args);
+  return normalize(parts);
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -148,4 +148,13 @@ describe('url join', function () {
   it('should return an empty string if no arguments are supplied', function() {
     urlJoin().should.eql('');
   });
+
+  it('should not mutate the original reference', function() {
+    const input = ['http:', 'www.google.com/', 'foo/bar', '?test=123'];
+    const expected = Array.from(input);
+
+    urlJoin(input);
+
+    input.should.eql(expected);
+  });
 });


### PR DESCRIPTION
Modernizes the syntax of the `urlJoin` function with ES2015. Also adds a regression test to ensure the original value passed to the function is not mutated.