### PR TITLE
Rewrite README.md to feature web standard APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fullUrl.hash = 'heading-1';
 fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 
-### Caveats for Standard APIs
+### Caveats of URL API
 There are a couple of caveats to take into account when utilizing the standard APIs. Firstly, a [URL][1] must always include a complete and valid base, which means specifying the scheme and domain name (e.g. http://example.com).
 
 Secondly, it is not possible to join together and normalize the path of a URL. You must do this manually by joining your paths and then assigning the pathname property.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 
 ### Caveats of URL API
-There are a couple of caveats to take into account when utilizing the standard APIs. Firstly, a [URL][1] must always include a complete and valid base, which means specifying the scheme and domain name (e.g. http://example.com).
+There are a couple of caveats to take into account when utilizing the standard APIs. Firstly, a `URL` must always include a complete and valid base, which means specifying the scheme and domain name (e.g. http://example.com).
 
 Secondly, it is not possible to join together and normalize the path of a URL. You must do this manually by joining your paths and then assigning the pathname property.
 
@@ -48,5 +48,3 @@ Use this library to manipulate URL pathnames
 ## License
 
 MIT
-
-[1]: https://developer.mozilla.org/en-US/docs/Web/API/URL_API

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This library was originally created before the [URL API](https://developer.mozil
 ### In the Browser
 
 For example, the equivalent code for the above example would look as follows when using the URL API:
+
 ```javascript
 const fullUrl = new URL('http://www.google.com');
 
@@ -36,25 +37,30 @@ fullUrl.hash = 'heading-1';
 console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 
-### Joining Path Parts
-This library provides the piece missing from `URL`, joining URL path parts together:
+### Joining paths
+
+This library provides the missing piece for the URL API, joining multiple paths together:
 
 ```javascript
 import urlJoin from 'url-join';
 
 const fullUrl = new URL('http://www.google.com');
-fullUrl.pathname = urlJoin('a', 'b', 'cd');
+
+fullUrl.pathname = urlJoin('a', '/b/cd');
 
 console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd'
 ```
 
 ### In Node.js
-If you are programming for Node.js, its `path/posix` library can join paths in a way that is compatible with URL pathnames:
+
+If you are using Node.js, the `path/posix` module can join paths in a way that is compatible with URL pathnames:
+
 ```javascript
 import { join as joinPath } from 'node:path/posix';
 
 const fullUrl = new URL('http://www.google.com');
-fullUrl.pathname = joinPath('/a/', 'b', 'cd');
+
+fullUrl.pathname = joinPath('a', '/b/cd');
 
 console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd'
 ```

--- a/README.md
+++ b/README.md
@@ -33,16 +33,10 @@ fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 
 ### Caveats of URL API
+
 There are a couple of caveats to take into account when utilizing the standard APIs. Firstly, a `URL` must always include a complete and valid base, which means specifying the scheme and domain name (e.g. http://example.com).
 
 Secondly, it is not possible to join together and normalize the path of a URL. You must do this manually by joining your paths and then assigning the pathname property.
-
-```
-Use this library to manipulate URL pathnames
-                                      👇
-   https  :// www.example.com /posts/42/metadata ?filter=author&page=1 #heading-1
-|-scheme-|    |---domain----| |----pathname----| |------search-------| |--hash--|
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 
 This library was originally created before the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL_API) was standardized and widely available in popular runtimes such as browsers and Node.js. Depending on your use-case you might want to consider using the standardized API over this library.
 
+For example, the equivalent code for the above example would look as follows when using the URL API:
 ```javascript
 const fullUrl = new URL('http://www.google.com');
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ If you want to use it directly in a browser use a CDN like [Skypack](https://www
 import urlJoin from 'url-join';
 
 const fullUrl = urlJoin('http://www.google.com', 'a', '/b/cd', '?foo=123', '&bar=456', '#heading-1');
-// 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
+
+console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
+
 ## You might not need this library
 
 This library was originally created before the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL_API) was standardized and widely available in popular runtimes such as browsers and Node.js. Depending on your use-case you might want to consider using the standardized API over this library.
+
+### In the Browser
 
 For example, the equivalent code for the above example would look as follows when using the URL API:
 ```javascript
@@ -29,7 +33,30 @@ fullUrl.searchParams.append('foo', '123');
 fullUrl.searchParams.append('bar', '456');
 fullUrl.hash = 'heading-1';
 
-fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
+console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
+```
+
+### Joining Path Parts
+This library provides the piece missing from `URL`, joining URL path parts together:
+
+```javascript
+import urlJoin from 'url-join';
+
+const fullUrl = new URL('http://www.google.com');
+fullUrl.pathname = urlJoin('a', 'b', 'cd');
+
+console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd'
+```
+
+### In Node.js
+If you are programming for Node.js, its `path/posix` library can join paths in a way that is compatible with URL pathnames:
+```javascript
+import { join as joinPath } from 'node:path/posix';
+
+const fullUrl = new URL('http://www.google.com');
+fullUrl.pathname = joinPath('/a/', 'b', 'cd');
+
+console.log(fullUrl.toString()); // 'http://www.google.com/a/b/cd'
 ```
 
 ### Caveats of URL API

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Join all path arguments together and normalize the resulting URL pathname. (No more duplicated or missing slashes!)
+Join all arguments together and normalize the resulting URL.
 
 
 ## Install
@@ -18,7 +18,7 @@ const id = '42'
 const postUrl = urlJoin('/posts', id, '/metadata/');
 // => "/posts/42/metadata"
 ```
-## Use the Web Standard APIs for Other Cases
+## You might not need this library
 
 Web Sandard APIs [URL][1] and [URLSearchParams][1] capable of URL operations except manipulating [URL pathnames][2].
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Join all arguments together and normalize the resulting URL.
 
-
 ## Install
 
 ```bash
@@ -14,13 +13,30 @@ If you want to use it directly in a browser use a CDN like [Skypack](https://www
 ```javascript
 import urlJoin from 'url-join';
 
-const id = '42'
-const postUrl = urlJoin('/posts', id, '/metadata/');
-// => "/posts/42/metadata"
+// Create a Full URL
+const fullUrl = urlJoin('http://www.google.com', 'a', '/b/cd', '?foo=123', '&bar=456', '#heading-1');
+fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 ## You might not need this library
 
-Web Sandard APIs [URL][1] and [URLSearchParams][1] capable of URL operations except manipulating [URL pathnames][2].
+This library was originally created before the [URL][1] and [URLSearchParams][1] APIs were standardized and widely available in popular runtimes such as browsers and Node.js. Depending on your use-case you might want to consider using these standardized APIs over this library.
+
+```javascript
+const fullUrl = new URL('http://www.google.com');
+
+fullUrl.pathname = '/a/b/cd';
+fullUrl.searchParams.append('foo', '123');
+fullUrl.searchParams.append('bar', '456');
+fullUrl.hash = 'heading-1';
+
+fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
+```
+
+### Caveats for Standard APIs
+There are a couple of caveats to take into account when utilizing the standard APIs. Firstly, a [URL][1] must always include a complete and valid base, which means specifying the scheme and domain name (e.g. http://example.com).
+
+Secondly, it is not possible to join together and normalize the path of a URL. You must do this manually by joining your paths and then assigning the pathname property.
+
 ```
 Use this library to manipulate URL pathnames
                                       👇
@@ -28,40 +44,8 @@ Use this library to manipulate URL pathnames
 |-scheme-|    |---domain----| |----pathname----| |------search-------| |--hash--|
 ```
 
-#### [`URL()`][1]
-
-- Join origin to pathname, deduplicating `/` between origin and pathname
-```js
-let url = new URL("/wiki/Early_history_of_the_IRT_subway", "https://wikipedia.org/")
-// => "https://wikipedia.org/wiki/Early_history_of_the_IRT_subway"
-```
-
-- Set the url hash
-```js
-let url = new URL("https://example.com/")
-url.hash = "heading-1"
-// => "https://example.com/#heading-1"
-```
-
-#### [`URLSearchParams()`][1]
-- Set query params on a URL
-```js
-let url = new URL("https://example.com/")
-url.search = new URLSearchParams([ ["foo", 123], ["bar", 456] ])
-// => "https://example.com/?foo=123&bar=456"
-```
-- Add query params to an existing URL
-```js
-let url = new URL("https://example.com/")
-url.searchParams.set('foo', 123) // to overwrite existing
-url.searchParams.append('bar', 456) // to add without overwriting
-// => "https://example.com/?foo=123&bar=456"
-```
-
 ## License
 
 MIT
 
-
 [1]: https://developer.mozilla.org/en-US/docs/Web/API/URL_API
-[2]: https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ If you want to use it directly in a browser use a CDN like [Skypack](https://www
 ```javascript
 import urlJoin from 'url-join';
 
-// Create a Full URL
 const fullUrl = urlJoin('http://www.google.com', 'a', '/b/cd', '?foo=123', '&bar=456', '#heading-1');
-fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
+// 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 ## You might not need this library
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ fullUrl.toString(); // 'http://www.google.com/a/b/cd?foo=123&bar=456#heading-1'
 ```
 ## You might not need this library
 
-This library was originally created before the [URL][1] and [URLSearchParams][1] APIs were standardized and widely available in popular runtimes such as browsers and Node.js. Depending on your use-case you might want to consider using these standardized APIs over this library.
+This library was originally created before the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL_API) was standardized and widely available in popular runtimes such as browsers and Node.js. Depending on your use-case you might want to consider using the standardized API over this library.
 
 ```javascript
 const fullUrl = new URL('http://www.google.com');

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Join all arguments together and normalize the resulting URL.
+Join all path arguments together and normalize the resulting URL pathname. (No more duplicated or missing slashes!)
+
 
 ## Install
 
@@ -13,17 +14,54 @@ If you want to use it directly in a browser use a CDN like [Skypack](https://www
 ```javascript
 import urlJoin from 'url-join';
 
-const fullUrl = urlJoin('http://www.google.com', 'a', '/b/cd', '?foo=123');
+const id = '42'
+const postUrl = urlJoin('/posts', id, '/metadata/');
+// => "/posts/42/metadata"
+```
+## Use the Web Standard APIs for Other Cases
 
-console.log(fullUrl);
+Web Sandard APIs [URL][1] and [URLSearchParams][1] capable of URL operations except manipulating [URL pathnames][2].
+```
+Use this library to manipulate URL pathnames
+                                      👇
+   https  :// www.example.com /posts/42/metadata ?filter=author&page=1 #heading-1
+|-scheme-|    |---domain----| |----pathname----| |------search-------| |--hash--|
 ```
 
-Prints:
+#### [`URL()`][1]
 
+- Join origin to pathname, deduplicating `/` between origin and pathname
+```js
+let url = new URL("/wiki/Early_history_of_the_IRT_subway", "https://wikipedia.org/")
+// => "https://wikipedia.org/wiki/Early_history_of_the_IRT_subway"
 ```
-'http://www.google.com/a/b/cd?foo=123'
+
+- Set the url hash
+```js
+let url = new URL("https://example.com/")
+url.hash = "heading-1"
+// => "https://example.com/#heading-1"
+```
+
+#### [`URLSearchParams()`][1]
+- Set query params on a URL
+```js
+let url = new URL("https://example.com/")
+url.search = new URLSearchParams([ ["foo", 123], ["bar", 456] ])
+// => "https://example.com/?foo=123&bar=456"
+```
+- Add query params to an existing URL
+```js
+let url = new URL("https://example.com/")
+url.searchParams.set('foo', 123) // to overwrite existing
+url.searchParams.append('bar', 456) // to add without overwriting
+// => "https://example.com/?foo=123&bar=456"
 ```
 
 ## License
 
 MIT
+
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/API/URL_API
+[2]: https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname


### PR DESCRIPTION
@jonkoops First attempt at rewriting the README.md to feature only merging URL pathnames. Also added a section on the standard web APIs. From discussion in #64.

Just a first attempt, so please dissect it.