### PR TITLE
Ensure single slashes do not duplicate

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -11,6 +11,11 @@ function normalize (strArray) {
     strArray[0] = strArray.shift() + strArray[0];
   }
 
+  // If the first part is a leading slash, we combine it with the next part.
+  if (strArray[0] === '/' && strArray.length > 1) {
+    strArray[0] = strArray.shift() + strArray[0];
+  }
+
   // There must be two or three slashes in the file protocol, two slashes in anything else.
   if (strArray[0].match(/^file:\/\/\//)) {
     strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///');
@@ -25,8 +30,6 @@ function normalize (strArray) {
       throw new TypeError('Url must be a string. Received ' + component);
     }
 
-    if (component === '') { continue; }
-
     if (i > 0) {
       // Removing the starting slashes for each component but the first.
       component = component.replace(/^[\/]+/, '');
@@ -39,8 +42,9 @@ function normalize (strArray) {
       component = component.replace(/[\/]+$/, '/');
     }
 
-    resultArray.push(component);
+    if (component === '') { continue; }
 
+    resultArray.push(component);
   }
 
   let str = resultArray.join('/');

--- a/test/tests.js
+++ b/test/tests.js
@@ -54,6 +54,11 @@ test('removes extra slashes in an encoded URL', () => {
     urlJoin('http://a.com/23d04b3/', '/b/c.html'),
     'http://a.com/23d04b3/b/c.html'
   );
+
+  assert.equal(
+    urlJoin("/foo", "/", "bar", "?test=123"),
+    "/foo/bar?test=123"
+  );
 });
 
 test('joins anchors in URLs', () => {


### PR DESCRIPTION
Removes any slashes that are non-leading to prevent duplication when joining later on.

Closes #103