### PR TITLE
Do not encode paramaters after the hash

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -54,8 +54,9 @@ function normalize (strArray) {
   str = str.replace(/\/(\?|&|#[^!])/g, '$1');
 
   // replace ? and & in parameters with &
-  const parts = str.split(/(?:\?|&)+/).filter(Boolean);
-  str = parts.shift() + (parts.length > 0 ? '?': '') + parts.join('&');
+  const [beforeHash, afterHash] = str.split('#');
+  const parts = beforeHash.split(/(?:\?|&)+/).filter(Boolean);
+  str = parts.shift() + (parts.length > 0 ? '?': '') + parts.join('&') + (afterHash && afterHash.length > 0 ? '#' + afterHash : '');
 
   return str;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -272,3 +272,10 @@ test('does not mutate the original input', () => {
 
   assert.deepEqual(input, expected);
 });
+
+test('does not replace query params after the hash', () => {
+  assert.equal(
+    urlJoin('http://example.com', '#a?b?c'),
+    'http://example.com#a?b?c'
+  );
+});


### PR DESCRIPTION
Prevents query parameters after the hash from being encoded by accident.

Closes #57