### PR TITLE
Do not add slashes between broken up query params or hash

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -47,7 +47,27 @@ function normalize (strArray) {
     resultArray.push(component);
   }
 
-  let str = resultArray.join('/');
+  let str = '';
+
+  for (let i = 0; i < resultArray.length; i++) {
+    const part = resultArray[i];
+
+    // Do not add a slash if this is the first part.
+    if (i === 0) {
+      str += part;
+      continue;
+    }
+
+    const prevPart = resultArray[i - 1]
+
+    // Do not add a slash if the previous part ends with start of the query param or hash.
+    if (prevPart && prevPart.endsWith('?') || prevPart.endsWith('#')) {
+      str += part;
+      continue;
+    }
+
+    str += '/' + part;
+  }
   // Each input component is now separated by a single slash except the possible first plain protocol part.
 
   // remove trailing slash before parameters or hash

--- a/test/tests.js
+++ b/test/tests.js
@@ -279,3 +279,17 @@ test('does not replace query params after the hash', () => {
     'http://example.com#a?b?c'
   );
 });
+
+test('joins broken up query params', () => {
+  assert.equal(
+    urlJoin('http://example.com', '/foo/bar?', 'test=123'),
+    'http://example.com/foo/bar?test=123'
+  );
+});
+
+test('joins broken up hash', () => {
+  assert.equal(
+    urlJoin('http://example.com', '/foo/bar#', 'some-hash'),
+    'http://example.com/foo/bar#some-hash'
+  );
+});


### PR DESCRIPTION
Prevents slashes from accidentally being added to the url when parts in in a hash or query param delimiter.

Closes #53