### PR TITLE
Filter out empty string values before joining

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -2,6 +2,9 @@ function normalize (strArray) {
   const resultArray = [];
   if (strArray.length === 0) { return ''; }
 
+  // Filter out any empty string values.
+  strArray = strArray.filter((part) => part !== '');
+
   if (typeof strArray[0] !== 'string') {
     throw new TypeError('Url must be a string. Received ' + strArray[0]);
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -293,3 +293,10 @@ test('joins broken up hash', () => {
     'http://example.com/foo/bar#some-hash'
   );
 });
+
+test('joins leading empty string', () => {
+  assert.equal(
+    urlJoin('', '/test'),
+    '/test'
+  );
+});


### PR DESCRIPTION
Filters out any empty string values before joining the URL.

Closes #45