### PR TITLE
Do not fix the protocol string if the first part is an IPv6 host

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -22,7 +22,8 @@ function normalize (strArray) {
   // There must be two or three slashes in the file protocol, two slashes in anything else.
   if (strArray[0].match(/^file:\/\/\//)) {
     strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///');
-  } else {
+  } else if (!strArray[0].match(/^\[.*:.*\]/)) {
+    // If the first part is not an IPv6 host, we replace the protocol.
     strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1://');
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -300,3 +300,24 @@ test('joins leading empty string', () => {
     '/test'
   );
 });
+
+test('joins a leading IPv6 hostname', () => {
+  assert.equal(
+    urlJoin('[2601:195:c381:3560::f42a]/', '/test'),
+    '[2601:195:c381:3560::f42a]/test'
+  );
+});
+
+test('joins a leading IPv6 host with an IPv4 address in the least significant 32 bits', () => {
+  assert.equal(
+    urlJoin('[2601:195:c381:3560::0.0.244.42]', '/test'),
+    '[2601:195:c381:3560::0.0.244.42]/test'
+  );
+});
+
+test('joins a protocol followed by an IPv6 host', () => {
+  assert.equal(
+    urlJoin('https://', '[2601:195:c381:3560::f42a]/', '/test'),
+    'https://[2601:195:c381:3560::f42a]/test'
+  );
+});


### PR DESCRIPTION
Fixes jfromaniello/url-join#108.

We only fix the first argument's protocol if it is definitely not an IPv6 host as defined by https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2. The regex checks for a '[' at the start of the string and a ']' with anything in between, but at least one ':'. This is sufficient because the linked RFC states that an IPv6 host is the "only place where square bracket characters are allowed in the URI syntax" (on page 19). An IPv6 address will always contain at least one ':'.