### PR TITLE
Add support for `./`

### DIFF
--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -34,6 +34,9 @@ function normalize (strArray) {
       throw new TypeError('Url must be a string. Received ' + component);
     }
 
+    // Remove periods from the beginning of the string (eg: './foo' -> '/foo').
+    component = component.replace(/^[.]\//, '/');
+
     if (i > 0) {
       // Removing the starting slashes for each component but the first.
       component = component.replace(/^[\/]+/, '');

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,6 +37,13 @@ test('joins a protocol with slashes', () => {
   );
 });
 
+test('Remove periods from paths', () => {
+  assert.equal(
+    urlJoin('http:', 'www.google.com/', 'foo/bar','./deee', '?test=123'),
+    'http://www.google.com/foo/bar/deee?test=123'
+  );
+});
+
 test('removes extra slashes', () => {
   assert.equal(
     urlJoin('http:', 'www.google.com///', 'foo/bar', '?test=123'),


### PR DESCRIPTION
Add support for relative paths URLs.

Taking inspiration from path.join(); If I do `path.join("/dede", "./defeee")` it will return `/dede/defeee`.